### PR TITLE
Enable /terms endpoint using TermsComponents

### DIFF
--- a/solr/transPlant-EBI/conf/solrconfig.xml
+++ b/solr/transPlant-EBI/conf/solrconfig.xml
@@ -27,6 +27,24 @@
     </lst>
   </requestHandler>
   
+    <!-- Terms Component
+       http://wiki.apache.org/solr/TermsComponent
+       A component to return terms and document frequency of those
+       terms
+    -->
+  <searchComponent name="terms" class="solr.TermsComponent"/>
+
+  <!-- A request handler for demonstrating the terms component -->
+  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
+     <lst name="defaults">
+      <bool name="terms">true</bool>
+      <bool name="distrib">true</bool>
+    </lst>     
+    <arr name="components">
+      <str>terms</str>
+    </arr>
+  </requestHandler>
+  
   <updateRequestProcessorChain name="dedupe">
     <processor class="solr.processor.SignatureUpdateProcessorFactory">
       <bool name="enabled">true</bool>

--- a/solr/transPlant-EBI/conf/solrconfig.xml
+++ b/solr/transPlant-EBI/conf/solrconfig.xml
@@ -26,7 +26,15 @@
       <str name="update.chain">dedupe</str>
     </lst>
   </requestHandler>
-  
+
+  <requestHandler name="/select" class="solr.SearchHandler" default="false">
+    <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <int name="rows">10</int>
+       <str name="df">description</str>
+    </lst>
+  </requestHandler>
+
     <!-- Terms Component
        http://wiki.apache.org/solr/TermsComponent
        A component to return terms and document frequency of those
@@ -34,11 +42,12 @@
     -->
   <searchComponent name="terms" class="solr.TermsComponent"/>
 
-  <!-- A request handler for demonstrating the terms component -->
   <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
      <lst name="defaults">
       <bool name="terms">true</bool>
-      <bool name="distrib">true</bool>
+      <str name="terms.fl">description</str>
+      <int name="terms.limit">10</int>
+      <int name="terms.mincount">10</int>
     </lst>     
     <arr name="components">
       <str>terms</str>

--- a/solr/transPlant-IPK/conf/solrconfig.xml
+++ b/solr/transPlant-IPK/conf/solrconfig.xml
@@ -26,6 +26,33 @@
       <str name="update.chain">dedupe</str>
     </lst>
   </requestHandler>
+
+  <requestHandler name="/select" class="solr.SearchHandler" default="false">
+    <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <int name="rows">10</int>
+       <str name="df">description</str>
+    </lst>
+  </requestHandler>
+
+    <!-- Terms Component
+       http://wiki.apache.org/solr/TermsComponent
+       A component to return terms and document frequency of those
+       terms
+    -->
+  <searchComponent name="terms" class="solr.TermsComponent"/>
+
+  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
+     <lst name="defaults">
+      <bool name="terms">true</bool>
+      <str name="terms.fl">description</str>
+      <int name="terms.limit">10</int>
+      <int name="terms.mincount">10</int>
+    </lst>     
+    <arr name="components">
+      <str>terms</str>
+    </arr>
+  </requestHandler>
   
   <updateRequestProcessorChain name="dedupe">
     <processor class="solr.processor.SignatureUpdateProcessorFactory">

--- a/solr/transPlant-MIPS/conf/solrconfig.xml
+++ b/solr/transPlant-MIPS/conf/solrconfig.xml
@@ -26,6 +26,33 @@
       <str name="update.chain">dedupe</str>
     </lst>
   </requestHandler>
+
+  <requestHandler name="/select" class="solr.SearchHandler" default="false">
+    <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <int name="rows">10</int>
+       <str name="df">description</str>
+    </lst>
+  </requestHandler>
+
+    <!-- Terms Component
+       http://wiki.apache.org/solr/TermsComponent
+       A component to return terms and document frequency of those
+       terms
+    -->
+  <searchComponent name="terms" class="solr.TermsComponent"/>
+
+  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
+     <lst name="defaults">
+      <bool name="terms">true</bool>
+      <str name="terms.fl">description</str>
+      <int name="terms.limit">10</int>
+      <int name="terms.mincount">10</int>
+    </lst>     
+    <arr name="components">
+      <str>terms</str>
+    </arr>
+  </requestHandler>
   
   <updateRequestProcessorChain name="dedupe">
     <processor class="solr.processor.SignatureUpdateProcessorFactory">

--- a/solr/transPlant-PAS/conf/solrconfig.xml
+++ b/solr/transPlant-PAS/conf/solrconfig.xml
@@ -26,6 +26,33 @@
       <str name="update.chain">dedupe</str>
     </lst>
   </requestHandler>
+
+  <requestHandler name="/select" class="solr.SearchHandler" default="false">
+    <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <int name="rows">10</int>
+       <str name="df">description</str>
+    </lst>
+  </requestHandler>
+
+    <!-- Terms Component
+       http://wiki.apache.org/solr/TermsComponent
+       A component to return terms and document frequency of those
+       terms
+    -->
+  <searchComponent name="terms" class="solr.TermsComponent"/>
+
+  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
+     <lst name="defaults">
+      <bool name="terms">true</bool>
+      <str name="terms.fl">description</str>
+      <int name="terms.limit">10</int>
+      <int name="terms.mincount">10</int>
+    </lst>     
+    <arr name="components">
+      <str>terms</str>
+    </arr>
+  </requestHandler>
   
   <updateRequestProcessorChain name="dedupe">
     <processor class="solr.processor.SignatureUpdateProcessorFactory">

--- a/solr/transPlant-URGI/conf/solrconfig.xml
+++ b/solr/transPlant-URGI/conf/solrconfig.xml
@@ -26,6 +26,33 @@
       <str name="update.chain">dedupe</str>
     </lst>
   </requestHandler>
+
+  <requestHandler name="/select" class="solr.SearchHandler" default="false">
+    <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <int name="rows">10</int>
+       <str name="df">description</str>
+    </lst>
+  </requestHandler>
+
+    <!-- Terms Component
+       http://wiki.apache.org/solr/TermsComponent
+       A component to return terms and document frequency of those
+       terms
+    -->
+  <searchComponent name="terms" class="solr.TermsComponent"/>
+
+  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
+     <lst name="defaults">
+      <bool name="terms">true</bool>
+      <str name="terms.fl">description</str>
+      <int name="terms.limit">10</int>
+      <int name="terms.mincount">10</int>
+    </lst>     
+    <arr name="components">
+      <str>terms</str>
+    </arr>
+  </requestHandler>
   
   <updateRequestProcessorChain name="dedupe">
     <processor class="solr.processor.SignatureUpdateProcessorFactory">

--- a/solr/transPlant/conf/solrconfig.xml
+++ b/solr/transPlant/conf/solrconfig.xml
@@ -11,8 +11,9 @@
     
     <lst name="defaults">
       
-      <!-- Add our shard servers... -->
-      <str name="shards">localhost:${jetty.port:8983}/solr/transPlant-EBI,localhost:${jetty.port:8983}/solr/transPlant-IPK,localhost:${jetty.port:8983}/solr/transPlant-MIPS,urgi.versailles.inra.fr/solr/URGI,cropnet.pl/solr-transplant-0.2,gwas.gmi.oeaw.ac.at:8983/solr</str>
+      <!-- Add our shard servers... 
+        transplant.shards is defined in core.properties  -->
+      <str name="shards">${transplant.shards}</str>
       
       <!-- Shards moved from local cores to remote cores:
            
@@ -57,6 +58,40 @@
     <lst name="defaults">
       <str name="update.chain">dedupe</str>
     </lst>
+  </requestHandler>
+
+  <requestHandler name="/select" class="solr.SearchHandler" default="false">
+    <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <int name="rows">10</int>
+       <str name="df">description</str>
+    </lst>
+  </requestHandler>
+
+    <!-- Terms Component
+       http://wiki.apache.org/solr/TermsComponent
+       A component to return terms and document frequency of those
+       terms
+    -->
+  <searchComponent name="terms" class="solr.TermsComponent"/>
+
+  <!-- A request handler for demonstrating the terms component -->
+  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
+     <lst name="defaults">
+      <bool name="terms">true</bool>
+      <bool name="distrib">true</bool><!-- Enable distribution of queries to shards -->
+      <str name="terms.fl">description</str><!-- Specifies the field from which to retrieve terms. -->
+      <int name="terms.limit">10</int><!-- Specifies the maximum number of terms to return. The default is 10. If the limit is set to a number
+less than 0, then no maximum limit is enforced. Although this is not required, either this parameter
+or terms.upper must be defined. -->
+      <int name="terms.mincount">10</int><!-- Specifies the minimum document frequency to return in order for a term to be included in a query
+response. Results are inclusive of the mincount. -->
+      <str name="shards">${transplant.shards}</str>
+      <str name="shards.qt">/terms</str>
+    </lst>     
+    <arr name="components">
+      <str>terms</str>
+    </arr>
   </requestHandler>
   
   <updateRequestProcessorChain name="dedupe">

--- a/solr/transPlant/core.properties
+++ b/solr/transPlant/core.properties
@@ -1,0 +1,1 @@
+transplant.shards=localhost:${jetty.port:8983}/solr/transPlant-EBI,localhost:${jetty.port:8983}/solr/transPlant-IPK,localhost:${jetty.port:8983}/solr/transPlant-MIPS,urgi.versailles.inra.fr/solr/URGI,cropnet.pl/solr-transplant-0.2,gwas.gmi.oeaw.ac.at:8983/solr


### PR DESCRIPTION
Ability to query /terms endpoint to return terms and documents frequency of those terms.
Distributed search is enabled for delegating requests to all shards defined at query time.
Details: http://wiki.apache.org/solr/TermsComponent
